### PR TITLE
fix publish by adding prepare script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+rm -rf pyret-lang
 git clone --single-branch -b horizon https://github.com/brownplt/pyret-lang.git
 
 pushd pyret-lang

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "build": "bash build.sh",
-    "test": "jest test/"
+    "test": "jest test/",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently the GitHub action isn't running build before it publishes. Adding a [`prepare` script](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) ensures this happens when running `npm publish`. Additionally, it allows installing the package through git.